### PR TITLE
Updated old "techguides" references to "r-techguides"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # techguides
 
 <!-- badges: start -->
-[![CI-CD](https://github.com/miraisolutions/techguides/actions/workflows/site.yaml/badge.svg)](https://github.com/miraisolutions/techguides/actions/workflows/site.yaml)
+[![CI-CD](https://github.com/miraisolutions/r-techguides/actions/workflows/site.yaml/badge.svg)](https://github.com/miraisolutions/r-techguides/actions/workflows/site.yaml)
 <!-- badges: end -->
 
 `techguides` is an open source project to collect technical guidelines and best practices. At [Mirai Solutions](https://mirai-solutions.ch) we envision `techguides` as a dynamic and evolving project where we can share with the community some of the experience we gather in our daily work.
 
-The current version of `techguides`, a [bookdown](https://github.com/rstudio/bookdown) website served via [GitHub Pages](https://pages.github.com), can be browsed at https://mirai-solutions.ch/techguides.
+The current version of `techguides`, a [bookdown](https://github.com/rstudio/bookdown) website served via [GitHub Pages](https://pages.github.com), can be browsed at https://mirai-solutions.ch/r-techguides.

--- a/index.Rmd
+++ b/index.Rmd
@@ -3,7 +3,7 @@ title: "Technical Guidelines for R"
 author: "Mirai Solutions"
 date: "`r Sys.time()`"
 description: "Best practices with R around select topics."
-github-repo: "miraisolutions/techguides"
+github-repo: "miraisolutions/r-techguides"
 site: bookdown::bookdown_site
 output:
   bookdown::gitbook:

--- a/roxygen-guidelines.Rmd
+++ b/roxygen-guidelines.Rmd
@@ -224,7 +224,7 @@ The following examples make use of the demo package `roxygenExPkg`. The package 
 
 ```{r github-install, eval = FALSE}
 remotes::install_github(
-  "miraisolutions/techguides/roxygen-guidelines/roxygenExPkg"
+  "miraisolutions/r-techguides/roxygen-guidelines/roxygenExPkg"
 )
 ```
 

--- a/roxygen-guidelines/roxygenExPkg/README.md
+++ b/roxygen-guidelines/roxygenExPkg/README.md
@@ -8,7 +8,7 @@ You can install roxygenExPkg from GitHub with:
 
 ``` r
 remotes::install_github(
-  "miraisolutions/techguides/roxygen-guidelines/roxygenExPkg"
+  "miraisolutions/r-techguides/roxygen-guidelines/roxygenExPkg"
 )
 ```
 

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -120,7 +120,7 @@ In order to setup and use CI/CD GitHub Actions workflows as described above, you
 
 ```{r}
 usethis::use_github_action(url = paste0(
-  "https://github.com/miraisolutions/techguides/blob/master/",
+  "https://github.com/miraisolutions/r-techguides/blob/master/",
   "shiny-ci-cd/actions/ci-cd.yml"
   # "shiny-ci-cd/actions/ci-cd-renv.yml"
   # "shiny-ci-cd/actions/ci.yml"


### PR DESCRIPTION
Mechanical replacement following the repo re-naming