### PR TITLE
Revise default target blank

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -27,7 +27,7 @@ output:
 printf "Last modified: %s" "$(git log -1 --format=%cd index.Rmd | sed 's/^[^ ]* //;s/ [^ ]*$//')"
 ```
 
-[**Mirai Solutions**](https://mirai-solutions.ch/) is a Zurich-based software development and consultancy firm, delivering cutting-edge technology and best practices to the industry, helping companies elevate their data analytics and operations.
+[**Mirai Solutions**](https://mirai-solutions.ch/){target="_blank"} is a Zurich-based software development and consultancy firm, delivering cutting-edge technology and best practices to the industry, helping companies elevate their data analytics and operations.
 
 We are an interdisciplinary team of data scientists, software engineers, business consultants and IT architects with specialist knowledge ranging from finance and risk management to math/stats techniques to software development and project management.
 
@@ -45,4 +45,4 @@ In this e-book, we share technical guidelines, how-tos and best practices around
 
 ![Python Logo](python-logo-only.png)
 
-If instead you are more interested in **Python**, you can access our free Python training material [**here**](https://mirai-solutions.ch/py-techguides).
+If instead you are more interested in **Python**, you can access our free Python training material [**here**](https://mirai-solutions.ch/py-techguides){target="_blank"}.

--- a/index.Rmd
+++ b/index.Rmd
@@ -8,11 +8,8 @@ site: bookdown::bookdown_site
 output:
   bookdown::gitbook:
     css: styles.css
-    includes:
-      in_header: target-blank.html
-    pandoc_args: ["--number-offset=0"]
-    # disable alt text rendered as figure caption
     split_by: section
+    # disable alt text rendered as figure caption
     fig_caption: false
     config:
       sharing:

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -15,7 +15,7 @@ cat(knitr::current_input(), file="tg-temp.txt")
 unlink("tg-temp.txt")
 ```
 
-For production readiness --- and project safety --- it is important to control the dependencies of a piece of development. This can be done at project level using the package [`renv`](https://rstudio.github.io/renv/).
+For production readiness --- and project safety --- it is important to control the dependencies of a piece of development. This can be done at project level using the package [`renv`](https://rstudio.github.io/renv/){target="_blank"}.
 
 In an `renv` project, dependencies are resolved and tracked in a lock-file. As a new R session starts, `renv` detects whether installed dependencies are out of sync compared to the lock-file, ensuring the same virtual environment applies each time the project is opened.
 
@@ -33,7 +33,7 @@ install.packages("renv")
 
 ## Set-up an `renv` project
 
-In order resolve and track dependencies of a project, `renv` needs to discover what the required packages are. Although `renv` supports discovering dependencies by scanning all files in the project (_implicit mode_), we strongly advise to define the required dependencies in a `DESCRIPTION` file, and rely on `renv`'s _explicit mode_ (see ['Snapshot types'](https://rstudio.github.io/renv/reference/snapshot.html#snapshot-types) in the documentation for details).
+In order resolve and track dependencies of a project, `renv` needs to discover what the required packages are. Although `renv` supports discovering dependencies by scanning all files in the project (_implicit mode_), we strongly advise to define the required dependencies in a `DESCRIPTION` file, and rely on `renv`'s _explicit mode_ (see ['Snapshot types'](https://rstudio.github.io/renv/reference/snapshot.html#snapshot-types){target="_blank"} in the documentation for details).
 
 To initialize `renv` for a project where dependencies are explicitly stated in the `DESCRIPTION` file, run:
 
@@ -99,7 +99,7 @@ If the `DESCRIPTION` file does not request a specific package version, `renv` wi
 options(repos = "https://packagemanager.posit.co/cran/2024-01-02")
 ```
 
-Date-based CRAN snapshots have built-in support in `renv` with [`renv::checkout()`](https://rstudio.github.io/renv/reference/checkout.html), w/o the need for `(options(repos = ...))`:
+Date-based CRAN snapshots have built-in support in `renv` with [`renv::checkout()`](https://rstudio.github.io/renv/reference/checkout.html){target="_blank"}, w/o the need for `(options(repos = ...))`:
 
 ```{r , echo = TRUE, eval = FALSE}
 # check out packages from PPM using the date '2023-01-02'

--- a/roxygen-guidelines.Rmd
+++ b/roxygen-guidelines.Rmd
@@ -26,7 +26,7 @@ This is based on:
 
 - **roxygen2** vignettes: `browseVignettes("roxygen2")`, in particular
 [Generating Rd
-files](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html).
+files](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html){target="_blank"}.
 - The [tidyverse style guide](https://style.tidyverse.org/documentation.html){target="_blank"}.
 - Package development experience.
 
@@ -141,7 +141,7 @@ Several techniques and tools are available to enable and support a more
 consistent and maintainable documentation.
 
 This can be described in detail in the [Do repeat
-yourself](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html#do-repeat-yourself)
+yourself](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html#do-repeat-yourself){target="_blank"}
 section of vignette _Generating Rd files_, and are summarized as follows
 
 - Cross-link documentation files with `@seealso` and `@family`.
@@ -180,7 +180,7 @@ man-roxygen/ex-<FUNCTION_NAME>.R`.
 
 Tags `@rdname` and `@describeIn` are a convenient way to document multiple
 functions in the same file. See the roxygen2 vignette [Generating Rd
-files](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html)
+files](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html){target="_blank"}
 (`vignette("rd", package = "roxygen2")`) for more detail.
 
 In both case, not that `@title` should be specified only for the _main_

--- a/roxygen-guidelines.Rmd
+++ b/roxygen-guidelines.Rmd
@@ -27,7 +27,7 @@ This is based on:
 - **roxygen2** vignettes: `browseVignettes("roxygen2")`, in particular
 [Generating Rd
 files](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html).
-- The [tidyverse style guide](https://style.tidyverse.org/documentation.html).
+- The [tidyverse style guide](https://style.tidyverse.org/documentation.html){target="_blank"}.
 - Package development experience.
 
 Examples are provided to show the concrete application of the described
@@ -100,7 +100,7 @@ bottom and in this order.
     - For **un-exported** objects documented for internal purposes, specify
     `@keywords internal` instead of `@export`.
 - Use
-[**markdown**](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html):
+[**markdown**](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html){target="_blank"}:
 If not done at package level, `@md` should be the last element (so it can easily
 be removed when moving to package-level).
 - Do not use `@rdname` if not documenting multiple objects (see below).

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -185,8 +185,8 @@ As default, Travis CI takes care of package dependency installation and performs
 
 ### Using renv for your project
 
-If your project relies on the package [renv](https://rstudio.github.io/renv/){target="_blank"} for tracking dependencies via an `renv.lock` file, you should override the default `install`ation package dependencies and make sure `cache`ing is adjusted accordingly, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv/articles/ci.html
-) vignette:
+If your project relies on the package [renv](https://rstudio.github.io/renv/){target="_blank"} for tracking dependencies via an `renv.lock` file, you should override the default `install`ation package dependencies and make sure `cache`ing is adjusted accordingly, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv/articles/ci.html){target="_blank"} vignette:
+
 ```yaml
 cache:
   directories:

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -15,7 +15,7 @@ cat(knitr::current_input(), file="tg-temp.txt")
 unlink("tg-temp.txt")
 ```
 
-It is good practice to integrate and develop an R Shiny app as an R package, to take full advantage of all the integrated features established for R packages (e.g., documentation, package namespaces, automated testing, `R CMD check`, etc.). A typical development workflow to package a Shiny app is provided by the [`golem` package](https://cran.r-project.org/web/packages/golem/index.html). Later in this chapter we will also indicate how to package a shiny app without the infrastructure provided by `golem`.
+It is good practice to integrate and develop an R Shiny app as an R package, to take full advantage of all the integrated features established for R packages (e.g., documentation, package namespaces, automated testing, `R CMD check`, etc.). A typical development workflow to package a Shiny app is provided by the [`golem` package](https://cran.r-project.org/web/packages/golem/index.html){target="_blank"}. Later in this chapter we will also indicate how to package a shiny app without the infrastructure provided by `golem`.
 
 Furthermore, version control systems such as Git are a great asset for keeping track an manage changes, especially in a collaborative setup.
 
@@ -24,9 +24,9 @@ The development of a packaged Shiny app under version control can easily enable 
 - Continuous Integration (CI) pipelines to automate checks and ensure higher code quality and robustness;
 - Continuous Deployment (CD) pipelines to automate the process of deployment to a _productive_ environment.
 
-This guide illustrates how to set up CI/CD pipelines with a focus on the increasingly popular [GitHub Actions](https://github.com/features/actions), which we recommend as a natural choice for GitHub open source projects. In particular, it shows how a Shiny app developed as an R package can be maintained on a GitHub repository, be deployed to and hosted on [shinyapps.io](https://www.shinyapps.io) using said CI/CD pipelines. For the sake of completeness, and for historical reasons, the guide also covers the CI/CD setup on [Travis CI](https://www.travis-ci.com), a well established service that has become not attractive any longer for open source projects due to its change of policy in recent years.
+This guide illustrates how to set up CI/CD pipelines with a focus on the increasingly popular [GitHub Actions](https://github.com/features/actions){target="_blank"}, which we recommend as a natural choice for GitHub open source projects. In particular, it shows how a Shiny app developed as an R package can be maintained on a GitHub repository, be deployed to and hosted on [shinyapps.io](https://www.shinyapps.io){target="_blank"} using said CI/CD pipelines. For the sake of completeness, and for historical reasons, the guide also covers the CI/CD setup on [Travis CI](https://www.travis-ci.com){target="_blank"}, a well established service that has become not attractive any longer for open source projects due to its change of policy in recent years.
 
-[ShinyCICD](https://github.com/miraisolutions/ShinyCICD) is a minimal example of a packaged Shiny app that will be used as an example throughout the guide. You can simply [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and setup your specific user settings (especially for shinyapps.io) to see CI/CD pipelines in actions, or follow the steps described in this chapter to setup CI/CD pipelines for your own app.
+[ShinyCICD](https://github.com/miraisolutions/ShinyCICD){target="_blank"} is a minimal example of a packaged Shiny app that will be used as an example throughout the guide. You can simply [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo){target="_blank"} the repository and setup your specific user settings (especially for shinyapps.io) to see CI/CD pipelines in actions, or follow the steps described in this chapter to setup CI/CD pipelines for your own app.
 
 ## Generic CI/CD pipeline
 
@@ -39,30 +39,30 @@ Generally speaking, a CI/CD pipeline related to an R package is comprised of the
 - build and check the package
 - deploy
 
-GitHub Actions provides great flexibility in specifying and customizing each individual step, but many are covered by the R-specific actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme) project. Most of these steps are implemented by default in Travis CI for an R package.
+GitHub Actions provides great flexibility in specifying and customizing each individual step, but many are covered by the R-specific actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme){target="_blank"} project. Most of these steps are implemented by default in Travis CI for an R package.
 
 ## GitHub Actions
 
-[GitHub Actions](https://docs.github.com/en/actions) is a service for running highly-customizable and flexible automated workflows, fully integrated with GitHub and very suitable to CI/CD pipelines. [Workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions) use `YAML` syntax and should be stored in the `.github/workflows` directory in the root of the repository. Workflows are constituted of jobs and each job is a set of steps to perform individual tasks, e.g. commands or actions.
+[GitHub Actions](https://docs.github.com/en/actions){target="_blank"} is a service for running highly-customizable and flexible automated workflows, fully integrated with GitHub and very suitable to CI/CD pipelines. [Workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions){target="_blank"} use `YAML` syntax and should be stored in the `.github/workflows` directory in the root of the repository. Workflows are constituted of jobs and each job is a set of steps to perform individual tasks, e.g. commands or actions.
 
 The next sections describe in detail the relevant workflow steps of a typical CI/CD pipeline for a packaged Shiny app, also covering the usage of `renv` to track package dependencies. Finally, we will show how you can use the convenience function `usethis::use_github_action()` for including such workflows in you project.
 
 ### Workflow steps
 
-A workflow should have an identifying `name` and an `on` section that indicates upon which events the workflow should be triggered. It should include at least one job and each job will have a set of steps fully specifying what to execute. Such steps can be an action (predefined, sourcing from GitHub repos that contain such actions) or custom shell commands. With the introduction of [composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action), most of the relevant workflow steps for an R project are covered by actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme) repository.
+A workflow should have an identifying `name` and an `on` section that indicates upon which events the workflow should be triggered. It should include at least one job and each job will have a set of steps fully specifying what to execute. Such steps can be an action (predefined, sourcing from GitHub repos that contain such actions) or custom shell commands. With the introduction of [composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action){target="_blank"}, most of the relevant workflow steps for an R project are covered by actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme){target="_blank"} repository.
 
 #### Setup
 
 - Checkout the source package from the repository, using `actions/checkout` provided by GitHub.
-- Setup R using the action [`r-lib/actions/setup-r`](https://github.com/r-lib/actions/tree/v2/setup-r#readme).
-- Install package dependencies (including system requirements and caching) using [`r-lib/actions/setup-r-dependencies`](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies#readme).
+- Setup R using the action [`r-lib/actions/setup-r`](https://github.com/r-lib/actions/tree/v2/setup-r#readme){target="_blank"}.
+- Install package dependencies (including system requirements and caching) using [`r-lib/actions/setup-r-dependencies`](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies#readme){target="_blank"}.
 
 ##### Using renv {-}
 
-If your project relies on package [renv](https://rstudio.github.io/renv/) for tracking dependencies via an `renv.lock` file, caching and installation of R package dependencies requires a different setup, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv//articles/ci.html#github-actions) vignette. As shown in the complete workflow files [below](#complete-wfs-use-gh-action):
+If your project relies on package [renv](https://rstudio.github.io/renv/){target="_blank"} for tracking dependencies via an `renv.lock` file, caching and installation of R package dependencies requires a different setup, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv//articles/ci.html#github-actions){target="_blank"} vignette. As shown in the complete workflow files [below](#complete-wfs-use-gh-action):
 
 - system requirements are installed explicitly (for the `ubuntu` runner defined for the workflow), based on `pkgdepends`.
-- dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/v2/setup-renv#readme).
+- dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/v2/setup-renv#readme){target="_blank"}.
 
 Some remarks about using an `renv` setup for a packaged Shiny app and a corresponding CI/CD workflow (see also our chapter ['Control dependencies with `renv`'](control-dependencies-with-renv.html) for details):
 
@@ -74,13 +74,13 @@ Some remarks about using an `renv` setup for a packaged Shiny app and a correspo
 
 #### Package check
 
-- Check the package using [`r-lib/actions/check-r-package`](https://github.com/r-lib/actions/tree/v2/check-r-package#readme).
+- Check the package using [`r-lib/actions/check-r-package`](https://github.com/r-lib/actions/tree/v2/check-r-package#readme){target="_blank"}.
 
 #### Deployment
 
 Continuous deployment to shinyapps.io is automated upon any push to the `main` (or `master`) branch.
 
-- In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub Actions [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+- In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications){target="_blank"} for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub Actions [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets){target="_blank"}.
 - Deployment to shinyapps.io is best configured and defined in an R script, e.g.  `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`), which:
   - sets up account credentials based on the environment variables for continuous deployment
   - deploys the app via `rsconnect::deployApp()`, specifying as files for deployment only what is relevant at run-time: this does not only prevent unnecessary files from being deployed, but also makes sure only run-time dependencies are captured in the deployment
@@ -158,7 +158,7 @@ usethis::use_github_actions_badge("ci-cd.yml") # or "ci.yml"/"ci(-cd)-renv.yml"
 
 ## Travis CI
 
-Travis CI is a continuous integration service that can be used to build and test software projects hosted on GitHub. To set up Travis CI you need to log in at [travis-ci.com](https://www.travis-ci.com) (using your GitHub account) and provide authorization via GitHub (see [Travis CI Onboarding](https://docs.travis-ci.com/user/onboarding/)).
+Travis CI is a continuous integration service that can be used to build and test software projects hosted on GitHub. To set up Travis CI you need to log in at [travis-ci.com](https://www.travis-ci.com){target="_blank"} (using your GitHub account) and provide authorization via GitHub (see [Travis CI Onboarding](https://docs.travis-ci.com/user/onboarding/){target="_blank"}).
 
 Travis CI used to be a very established, mature and popular tool in the open-source source community, before a recent change of policy made it less focused on open-source, offering only limited free trial plans.
 
@@ -185,7 +185,7 @@ As default, Travis CI takes care of package dependency installation and performs
 
 ### Using renv for your project
 
-If your project relies on the package [renv](https://rstudio.github.io/renv/) for tracking dependencies via an `renv.lock` file, you should override the default `install`ation package dependencies and make sure `cache`ing is adjusted accordingly, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv/articles/ci.html
+If your project relies on the package [renv](https://rstudio.github.io/renv/){target="_blank"} for tracking dependencies via an `renv.lock` file, you should override the default `install`ation package dependencies and make sure `cache`ing is adjusted accordingly, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv/articles/ci.html
 ) vignette:
 ```yaml
 cache:
@@ -200,7 +200,7 @@ install:
 
 ### Automated deployment
 
-Travis CI can be setup to perform a deployment (e.g. publish a shiny app on [shinyapps.io](https://www.shinyapps.io/)) upon any push to the `master` branch, provided the CI checks pass.
+Travis CI can be setup to perform a deployment (e.g. publish a shiny app on [shinyapps.io](https://www.shinyapps.io/){target="_blank"}) upon any push to the `master` branch, provided the CI checks pass.
 
 This is achieved for a shinyapps.io deployment by specifying in `.travis.yml` an additional `deploy:` section as
 
@@ -218,7 +218,7 @@ deploy:
     branch: master
 ```
 
-where `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN`, `SHINYAPPS_SECRET` are [secure variables defined on Travis CI](https://docs.travis-ci.com/user/environment-variables/) holding your account name and corresponding  [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io.
+where `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN`, `SHINYAPPS_SECRET` are [secure variables defined on Travis CI](https://docs.travis-ci.com/user/environment-variables/){target="_blank"} holding your account name and corresponding  [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications){target="_blank"} for shinyapps.io.
 
 It is in fact more convenient to write an R script, saved as e.g. `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`) defining the deployment commands:
 ```{r deploy-shinyapps}
@@ -260,7 +260,7 @@ As visible from the run logs, all the CI/CD pipeline steps are performed, despit
 
 It makes sense to structure shiny applications as a package to better control their dependencies. However, some structural conditions are required for the deployment of a packaged shiny application. 
 
-As already mentioned, one option is to use the [`golem` package](https://cran.r-project.org/web/packages/golem/index.html), which will initialize the shiny application with its framework that does support deployment of a shiny application as a package. But sometimes you may not want to add an entire framework to an existing application and instead add this support manually.
+As already mentioned, one option is to use the [`golem` package](https://cran.r-project.org/web/packages/golem/index.html){target="_blank"}, which will initialize the shiny application with its framework that does support deployment of a shiny application as a package. But sometimes you may not want to add an entire framework to an existing application and instead add this support manually.
 
 Since we did not find any good documentation of this online (as of Nov 2020), we investigated this ourselves and are happy to share our findings here.
 
@@ -293,4 +293,4 @@ In the beginning of the `ui` function, we also need to add a call to `shiny::add
 
 ### non-CRAN dependencies
 
-Deploying a packaged shiny application which uses non-CRAN package sources like Github requires additional information in the `DESCRIPTION` file. Namely, the repository details of such dependencies must be included in a [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) field, so that tools like `renv` or `remotes` know where the packages should be retrieved from.
+Deploying a packaged shiny application which uses non-CRAN package sources like Github requires additional information in the `DESCRIPTION` file. Namely, the repository details of such dependencies must be included in a [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html){target="_blank"} field, so that tools like `renv` or `remotes` know where the packages should be retrieved from.

--- a/target-blank.html
+++ b/target-blank.html
@@ -1,3 +1,0 @@
-<head>
-    <base target="_blank">
-</head>

--- a/version-stable-r-development.Rmd
+++ b/version-stable-r-development.Rmd
@@ -75,7 +75,7 @@ Linux systems), where only one R version (the latest release) exists.
 The idea is then to rely on the same version-stable rocker containers used for
 the deployments, using a containerized versioned RStudio instance for the local
 development. This is available through Rocker's [versioned
-stack](https://www.rocker-project.org/images/#the-versioned-stack), so we could
+stack](https://www.rocker-project.org/images/#the-versioned-stack){target="_blank"}, so we could
 use e.g. `rocker/rstudio:4.4.1`.
 
 Note that the same version-stable instance of RStudio can be used across all
@@ -111,7 +111,7 @@ container and be shared with it (and possibly multiple other containers), e.g. u
 `~/workspace` on the host machine and `/home/rstudio/workspace` in
 the container.
     - For this to work w/o [permission
-    issues](https://rocker-project.org/images/versioned/rstudio.html#userid-and-groupid),
+    issues](https://rocker-project.org/images/versioned/rstudio.html#userid-and-groupid){target="_blank"},
     the container user (`rstudio`) must match the UID of the host user (`$UID`). 
     This has the effect of setting the ownership of `~/workspace` on the host machine to `$UID` if it is not already owned by that user.
 - In order for the RStudio settings to persist if the container is recreated

--- a/version-stable-r-development.Rmd
+++ b/version-stable-r-development.Rmd
@@ -25,13 +25,13 @@ the development setup to (alternative) target productive stages.
 
 This guide illustrates an approach to manage a version-stable R development
 environment based on containerized solutions leveraging the
-[Rocker project](https://www.rocker-project.org/), allowing the coexistence
+[Rocker project](https://www.rocker-project.org/){target="_blank"}, allowing the coexistence
 of multiple dockerized development flavors, to match various target production
 environments or projects.
 
 > _The instructions in this chapter are for R >= 4.0.0.
 Images for R <= 3.6.3 are defined in 
-[rocker-org/rocker-versioned](https://github.com/rocker-org/rocker-versioned),
+[rocker-org/rocker-versioned](https://github.com/rocker-org/rocker-versioned){target="_blank"},
 but are no longer actively maintained._
 
 
@@ -40,8 +40,8 @@ but are no longer actively maintained._
 When deploying R applications (e.g. a Shiny app) using Docker containers, it is
 important to control versioning of R and packages for the sake of reproducibility
 and stability of the deployments. For this reason,
-[version-stable](https://github.com/rocker-org/rocker-versioned2) images are
-provided as part of the [Rocker project](https://www.rocker-project.org/) and
+[version-stable](https://github.com/rocker-org/rocker-versioned2){target="_blank"} images are
+provided as part of the [Rocker project](https://www.rocker-project.org/){target="_blank"} and
 used as a basis for deploying productive applications.
 
 Each version-stable Rocker image has an associated _tag_ for all non-latest R
@@ -49,7 +49,7 @@ versions (e.g. `rocker/r-ver:4.4.1`). Besides being specific to the
 corresponding version of R, each tag fixes the version of contributed packages
 (by using as package repository the CRAN snapshot of the last day CRAN
 distributed that R version as latest release). See
-[wiki/Versions](https://github.com/rocker-org/rocker-versioned2/wiki/Versions).
+[wiki/Versions](https://github.com/rocker-org/rocker-versioned2/wiki/Versions){target="_blank"}.
 If that R version is the latest, the CRAN date will not be set and the latest packages will always be installed.
 
 
@@ -59,7 +59,7 @@ image tag to start `FROM`, e.g.
 FROM rocker/r-ver:4.4.1
 ```
 See
-[SmaRP/Dockerfile](https://github.com/miraisolutions/SmaRP/blob/feature/upgrade-latest-r/Dockerfile)
+[SmaRP/Dockerfile](https://github.com/miraisolutions/SmaRP/blob/feature/upgrade-latest-r/Dockerfile){target="_blank"}
 for an example.
 <!-- NOTE: Not yet merged into master, to be replaced with https://github.com/miraisolutions/SmaRP/blob/master/Dockerfile -->
 
@@ -105,7 +105,7 @@ following setup:
 - Use a version-specific port, e.g. `4000` for R 4.0.0, `4410` for R 4.4.1 and
 so on, so that we can use `localhost` for concurrent R version instances. 
 We bind the port to localhost (`127.0.0.1:4410`), so it is only accessible locally 
-(see [the Rocker reference](https://rocker-project.org/images/versioned/rstudio.html#disable_auth)).
+(see [the Rocker reference](https://rocker-project.org/images/versioned/rstudio.html#disable_auth){target="_blank"}).
 - The development code of all relevant projects should live outside the
 container and be shared with it (and possibly multiple other containers), e.g. under
 `~/workspace` on the host machine and `/home/rstudio/workspace` in
@@ -118,7 +118,7 @@ the container.
 (e.g. after pulling a new `rocker` image), we also use a shared volume (like
 `~/.rstudio-config/4.4.1`) for the `/home/rstudio/.config/rstudio` directory, which is
 version-specific in case of multiple R versions.
-- If we want to use Meld via the [compareWith](https://github.com/miraisolutions/compareWith/) addins, we need to
+- If we want to use Meld via the [compareWith](https://github.com/miraisolutions/compareWith/){target="_blank"} addins, we need to
     - map the `DISPLAY` environment variable and volume `/tmp/.X11-unix`,
     - add `DISPLAY` to `Renviron`,
     - install Meld,
@@ -222,14 +222,14 @@ Because of this, RStudio does not set the desired home directory as the initial 
 echo '{ "initial_working_directory": "/home/rstudio" }' > $HOME/.rstudio-config/$R_VER/rstudio-prefs.json &&
 ```
 After `mkdir -p $HOME/.rstudio-config/$R_VER` in the `run_rstudio_ver` function.
-If you run into issues, the discussion in this rocker [pull request](https://github.com/rocker-org/rocker-versioned2/pull/636)
+If you run into issues, the discussion in this rocker [pull request](https://github.com/rocker-org/rocker-versioned2/pull/636){target="_blank"}
 about rootless container support may help.
 
 ### Best-supported R versions
-This tutorial uses images based on the [rocker-versioned2](https://github.com/rocker-org/rocker-versioned2) repository.
+This tutorial uses images based on the [rocker-versioned2](https://github.com/rocker-org/rocker-versioned2){target="_blank"} repository.
 We recommend using the latest patch version for each minor version - e.g. 4.0.5 for 4.0.x,
 as these seem to be the most regularly updated images
-(see e.g. [rocker/verse on docker hub](https://hub.docker.com/r/rocker/verse/tags?page=&page_size=&ordering=&name=4.0.)).
+(see e.g. [rocker/verse on docker hub](https://hub.docker.com/r/rocker/verse/tags?page=&page_size=&ordering=&name=4.0.){target="_blank"}).
 
 
 ### Cleanup
@@ -241,8 +241,8 @@ docker rm $(docker stop rstudio_4.4.1)
 
 ## References
 
-- [The Rocker Project](https://www.rocker-project.org/)
-- [Shared Volumes](https://www.rocker-project.org/use/shared_volumes/)
-- [Rocker Wiki](https://github.com/rocker-org/rocker/wiki)
-- [Sharing files with host machine](https://github.com/rocker-org/rocker/wiki/Sharing-files-with-host-machine)
-- [Rocker reference for verse and other images](https://rocker-project.org/images/versioned/rstudio.html) (in particular [how to use](https://rocker-project.org/images/versioned/rstudio.html#how-to-use))
+- [The Rocker Project](https://www.rocker-project.org/){target="_blank"}
+- [Shared Volumes](https://www.rocker-project.org/use/shared_volumes/){target="_blank"}
+- [Rocker Wiki](https://github.com/rocker-org/rocker/wiki){target="_blank"}
+- [Sharing files with host machine](https://github.com/rocker-org/rocker/wiki/Sharing-files-with-host-machine){target="_blank"}
+- [Rocker reference for verse and other images](https://rocker-project.org/images/versioned/rstudio.html){target="_blank"} (in particular [how to use](https://rocker-project.org/images/versioned/rstudio.html#how-to-use){target="_blank"})

--- a/xlconnect.Rmd
+++ b/xlconnect.Rmd
@@ -16,7 +16,7 @@ unlink("tg-temp.txt")
 ```
 
 MS Excel is probably the most used support to share data analysis and reports in enterprise. Despite its popularity, performing data analysis within an Excel workbook can be cumbersome as well as error prone due to irreproducibility. A possible way out is to perform most of the steps of your data analysis and reporting in another programming language, such as R, and just present and share the results in Excel. 
-Using the package [`XLConnect`](https://github.com/miraisolutions/xlconnect) will allow you to read, write and manipulate MS Excel files from within R.
+Using the package [`XLConnect`](https://github.com/miraisolutions/xlconnect){target="_blank"} will allow you to read, write and manipulate MS Excel files from within R.
 
 XLConnect's main features:
 


### PR DESCRIPTION
Revise the default opening of all links in a new tab (`target="_blank"`) done in #50 (58105c3495b702507a8b5b7fb5858e5776511428)

- It breaks the search, as the dummy hash `#` link for the search is also opened in a new tab, where the search box does not even appear.
- It also opens internal links (including section hashes) to the r-techguides in a new tab.
- Also purge the unnecessary `pandoc_args`, introduced in the same commit.

Instead, all external links have an explicit `target="_blank"`

- Done by batch regex replacement `(\[[^\]]+\]\(http[^)]+\))` => `$1{target="_blank"}`