### PR TITLE
Revise document path for Git modified date child document

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -26,8 +26,9 @@ output:
 
 # Introduction {-}
 
-```{bash mod-date, engine.opts='-l', echo=FALSE, comment=""}
-printf "Last modified: %s" "$(git log -1 --format=%cd index.Rmd | sed 's/^[^ ]* //;s/ [^ ]*$//')"
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 [**Mirai Solutions**](https://mirai-solutions.ch/) is a Zurich-based software development and consultancy firm, delivering cutting-edge technology and best practices to the industry, helping companies elevate their data analytics and operations.

--- a/mod-date.Rmd
+++ b/mod-date.Rmd
@@ -1,3 +1,7 @@
-```{bash mod-date, engine.opts='-l', echo=FALSE}
-printf "Last modified: %s" "$(git log -1 --format=%cd $(cat tg-temp.txt) | sed 's/^[^ ]* //;s/ [^ ]*$//')"
+```{r set-mod-date, eval=TRUE, include=FALSE}
+Sys.setenv(KNITR_CURRENT_INPUT = knitr_current_input)
+```
+
+```{bash mood-date, engine.opts='-l', eval=TRUE, echo=FALSE, comment="", message=FALSE}
+printf "Last modified: %s" "$(git log -1 --format=%cd $KNITR_CURRENT_INPUT | sed 's/^[^ ]* //;s/ [^ ]*$//')"
 ```

--- a/mod-date.Rmd
+++ b/mod-date.Rmd
@@ -1,7 +1,7 @@
-```{r set-mod-date, eval=TRUE, include=FALSE}
+```{r mod-date-setenv, eval=TRUE, include=FALSE}
 Sys.setenv(KNITR_CURRENT_INPUT = knitr_current_input)
 ```
 
-```{bash mood-date, engine.opts='-l', eval=TRUE, echo=FALSE, comment="", message=FALSE}
+```{bash mod-date-print, engine.opts='-l', eval=TRUE, echo=FALSE, comment="", message=FALSE}
 printf "Last modified: %s" "$(git log -1 --format=%cd $KNITR_CURRENT_INPUT | sed 's/^[^ ]* //;s/ [^ ]*$//')"
 ```

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -4,15 +4,9 @@
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, eval = FALSE)
 ```
 
-```{r topic-envvar, include = FALSE, eval=TRUE}
-cat(knitr::current_input(), file="tg-temp.txt")
-```
-
-```{r mod-date, child=c('mod-date.Rmd'), comment="", eval=TRUE}
-```
-
-```{r envvar-unlink, include = FALSE, eval=TRUE}
-unlink("tg-temp.txt")
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 For production readiness --- and project safety --- it is important to control the dependencies of a piece of development. This can be done at project level using the package [`renv`](https://rstudio.github.io/renv/).

--- a/roxygen-guidelines.Rmd
+++ b/roxygen-guidelines.Rmd
@@ -7,15 +7,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r topic-envvar, include = FALSE, eval=TRUE}
-cat(knitr::current_input(), file="tg-temp.txt")
-```
-
-```{r mod-date, child=c('mod-date.Rmd'), comment="", eval=TRUE}
-```
-
-```{r envvar-unlink, include = FALSE, eval=TRUE}
-unlink("tg-temp.txt")
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 The scope of this document is to provide *opinionated yet motivated

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -4,15 +4,9 @@
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, eval = FALSE)
 ```
 
-```{r topic-envvar, include = FALSE, eval=TRUE}
-cat(knitr::current_input(), file="tg-temp.txt")
-```
-
-```{r mod-date, child=c('mod-date.Rmd'), comment="", eval=TRUE}
-```
-
-```{r envvar-unlink, include = FALSE, eval=TRUE}
-unlink("tg-temp.txt")
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 It is good practice to integrate and develop an R Shiny app as an R package, to take full advantage of all the integrated features established for R packages (e.g., documentation, package namespaces, automated testing, `R CMD check`, etc.). A typical development workflow to package a Shiny app is provided by the [`golem` package](https://cran.r-project.org/web/packages/golem/index.html). Later in this chapter we will also indicate how to package a shiny app without the infrastructure provided by `golem`.

--- a/version-stable-r-development.Rmd
+++ b/version-stable-r-development.Rmd
@@ -5,15 +5,9 @@
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, eval = FALSE)
 ```
 
-```{r topic-envvar, include = FALSE, eval=TRUE}
-cat(knitr::current_input(), file="tg-temp.txt")
-```
-
-```{r mod-date, child=c('mod-date.Rmd'), comment="", eval=TRUE}
-```
-
-```{r envvar-unlink, include = FALSE, eval=TRUE}
-unlink("tg-temp.txt")
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 In the context of productive solutions, it is essential to have full control

--- a/xlconnect.Rmd
+++ b/xlconnect.Rmd
@@ -4,15 +4,9 @@
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, eval = FALSE)
 ```
 
-```{r topic-envvar, include = FALSE, eval=TRUE}
-cat(knitr::current_input(), file="tg-temp.txt")
-```
-
-```{r mod-date, child=c('mod-date.Rmd'), comment="", eval=TRUE}
-```
-
-```{r envvar-unlink, include = FALSE, eval=TRUE}
-unlink("tg-temp.txt")
+```{r mod-date, eval=TRUE, echo=FALSE, results='asis'}
+mod_date_envir <- list2env(list(knitr_current_input = knitr::current_input()))
+cat(knitr::knit_child("mod-date.Rmd", quiet = TRUE, envir = mod_date_envir))
 ```
 
 MS Excel is probably the most used support to share data analysis and reports in enterprise. Despite its popularity, performing data analysis within an Excel workbook can be cumbersome as well as error prone due to irreproducibility. A possible way out is to perform most of the steps of your data analysis and reporting in another programming language, such as R, and just present and share the results in Excel. 


### PR DESCRIPTION
* By using `knit_child()` explicitly and placing the path in the environment used for rendering the child.
* To replace the need for writing to a file and using multiple chinks.

This is an approach we used already in the first MiraiLabs: [From prototype to production](https://github.com/miraisolutions/MiraiLabs/blob/master/from-prototype-to-production)