### PR TITLE
Rename Rproj to r-techguides following repo renaming

### DIFF
--- a/r-techguides.Rproj
+++ b/r-techguides.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 8722ad11-c65b-4a29-bdd2-7bb7f7db374f
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
* Leftover from #51
* The new ProjectId is by now always included when opening the project in RStudio