### PR TITLE
minor update for r-techguides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-# techguides
+# r-techguides
 
 <!-- badges: start -->
 [![CI-CD](https://github.com/miraisolutions/r-techguides/actions/workflows/site.yaml/badge.svg)](https://github.com/miraisolutions/r-techguides/actions/workflows/site.yaml)
@@ -7,4 +6,4 @@
 
 `techguides` is an open source project to collect technical guidelines and best practices. At [Mirai Solutions](https://mirai-solutions.ch) we envision `techguides` as a dynamic and evolving project where we can share with the community some of the experience we gather in our daily work.
 
-The current version of `techguides`, a [bookdown](https://github.com/rstudio/bookdown) website served via [GitHub Pages](https://pages.github.com), can be browsed at https://mirai-solutions.ch/r-techguides.
+The current version of our R `techguides`, a [bookdown](https://github.com/rstudio/bookdown) website served via [GitHub Pages](https://pages.github.com), can be browsed at https://mirai-solutions.ch/r-techguides.


### PR DESCRIPTION
I left it `techguides` in the middle paragraph intentionally as a generic initiative.